### PR TITLE
fix(csp): allow Cloudflare Web Analytics beacon

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,11 +7,11 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 // You might need to insert additional domains in script-src if you are using external services
 const ContentSecurityPolicy = `
   default-src 'self';
-  script-src 'self' 'unsafe-eval' 'unsafe-inline' giscus.app analytics.umami.is us.umami.is;
+  script-src 'self' 'unsafe-eval' 'unsafe-inline' giscus.app analytics.umami.is us.umami.is static.cloudflareinsights.com;
   style-src 'self' 'unsafe-inline';
   img-src 'self' blob: data: https:;
   media-src 'self' https://*.s3.amazonaws.com;
-  connect-src 'self' analytics.umami.is us.umami.is;
+  connect-src 'self' analytics.umami.is us.umami.is cloudflareinsights.com;
   font-src 'self';
   frame-src 'self' giscus.app;
   object-src 'none';

--- a/public/_headers
+++ b/public/_headers
@@ -17,7 +17,7 @@
   Permissions-Policy: camera=(), microphone=(), geolocation=()
 
 /*
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' giscus.app analytics.umami.is us.umami.is; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: https:; media-src 'self' https://*.s3.amazonaws.com; connect-src 'self' analytics.umami.is us.umami.is; font-src 'self'; frame-src 'self' giscus.app; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' giscus.app analytics.umami.is us.umami.is static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: https:; media-src 'self' https://*.s3.amazonaws.com; connect-src 'self' analytics.umami.is us.umami.is cloudflareinsights.com; font-src 'self'; frame-src 'self' giscus.app; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests
   Referrer-Policy: strict-origin-when-cross-origin
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff


### PR DESCRIPTION
Cloudflare auto-injects beacon.min.js from static.cloudflareinsights.com and reports to cloudflareinsights.com; both were blocked by the CSP. Add them to script-src/connect-src in next.config.js and public/_headers.