### PR TITLE
fix(csp): allow Umami Cloud (cloud.umami.is) + shorten resume PDF cache

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,11 +7,11 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 // You might need to insert additional domains in script-src if you are using external services
 const ContentSecurityPolicy = `
   default-src 'self';
-  script-src 'self' 'unsafe-eval' 'unsafe-inline' giscus.app analytics.umami.is us.umami.is static.cloudflareinsights.com;
+  script-src 'self' 'unsafe-eval' 'unsafe-inline' giscus.app analytics.umami.is us.umami.is cloud.umami.is static.cloudflareinsights.com;
   style-src 'self' 'unsafe-inline';
   img-src 'self' blob: data: https:;
   media-src 'self' https://*.s3.amazonaws.com;
-  connect-src 'self' analytics.umami.is us.umami.is cloudflareinsights.com;
+  connect-src 'self' analytics.umami.is us.umami.is cloud.umami.is cloudflareinsights.com;
   font-src 'self';
   frame-src 'self' giscus.app;
   object-src 'none';

--- a/public/_headers
+++ b/public/_headers
@@ -9,6 +9,7 @@
 # The resume page embeds this PDF in a same-origin iframe, so it must NOT be
 # X-Frame-Options: DENY. Self-contained so it's correct regardless of merge order.
 /Kunj_Patel_Senior_Security_Engineer.pdf
+  Cache-Control: public, max-age=300, must-revalidate
   X-Frame-Options: SAMEORIGIN
   Content-Security-Policy: frame-ancestors 'self'
   Referrer-Policy: strict-origin-when-cross-origin
@@ -17,7 +18,7 @@
   Permissions-Policy: camera=(), microphone=(), geolocation=()
 
 /*
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' giscus.app analytics.umami.is us.umami.is static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: https:; media-src 'self' https://*.s3.amazonaws.com; connect-src 'self' analytics.umami.is us.umami.is cloudflareinsights.com; font-src 'self'; frame-src 'self' giscus.app; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' giscus.app analytics.umami.is us.umami.is cloud.umami.is static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: https:; media-src 'self' https://*.s3.amazonaws.com; connect-src 'self' analytics.umami.is us.umami.is cloud.umami.is cloudflareinsights.com; font-src 'self'; frame-src 'self' giscus.app; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests
   Referrer-Policy: strict-origin-when-cross-origin
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff


### PR DESCRIPTION
- Umami now 301-redirects analytics.umami.is/script.js to cloud.umami.is, which was blocked by CSP. Add cloud.umami.is to script-src and connect-src.
- Add Cache-Control: max-age=300 to the resume PDF so header changes (e.g. the X-Frame-Options fix) propagate in minutes instead of the prior 4 hours.